### PR TITLE
replace .ext. with _

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The common usage looks like this:
 
 ```python
 from starlette.applications import Starlette
-from gino.ext.starlette import Gino
+from gino_starlette import Gino
 
 app = Starlette()
 db = Gino(app, **kwargs)

--- a/examples/prod_fastapi_demo/src/gino_fastapi_demo/models/__init__.py
+++ b/examples/prod_fastapi_demo/src/gino_fastapi_demo/models/__init__.py
@@ -1,4 +1,4 @@
-from gino.ext.starlette import Gino
+from gino_starlette import Gino
 
 from .. import config
 

--- a/examples/prod_fastapi_demo/tests/test_users.py
+++ b/examples/prod_fastapi_demo/tests/test_users.py
@@ -8,7 +8,7 @@ def test_crud(client):
     r.raise_for_status()
 
     # retrieve
-    url = "/users/{}".format(r.json()['id'])
+    url = "/users/{}".format(r.json()["id"])
     assert client.get(url).json()["nickname"] == nickname
 
     # delete

--- a/examples/simple_fastapi_demo/app.py
+++ b/examples/simple_fastapi_demo/app.py
@@ -1,7 +1,7 @@
 import os
 
 from fastapi import FastAPI
-from gino.ext.starlette import Gino
+from gino_starlette import Gino
 from pydantic import BaseModel
 
 app = FastAPI()

--- a/examples/simple_starlette_demo/app.py
+++ b/examples/simple_starlette_demo/app.py
@@ -1,6 +1,6 @@
 import os
 
-from gino.ext.starlette import Gino
+from gino_starlette import Gino
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse
 

--- a/src/gino_starlette.py
+++ b/src/gino_starlette.py
@@ -11,7 +11,7 @@ from starlette import status
 from starlette.exceptions import HTTPException
 from starlette.types import Receive, Scope, Send
 
-logger = logging.getLogger("gino.ext.starlette")
+logger = logging.getLogger("gino_starlette")
 
 
 class StarletteModelMixin:
@@ -92,7 +92,7 @@ class Gino(_Gino):
     The common usage looks like this::
 
         from starlette.applications import Starlette
-        from gino.ext.starlette import Gino
+        from gino_starlette import Gino
 
         app = Starlette()
         db = Gino(app, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import asyncpg
 import gino
 import pytest
 import requests
-from gino.ext.starlette import Gino
+from gino_starlette import Gino
 from requests.adapters import HTTPAdapter
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse


### PR DESCRIPTION
`gino.ext.starlette` should be replaced since lint tools work poorly with it


![image](https://user-images.githubusercontent.com/4182346/91521593-f9fd8700-e932-11ea-9de9-706fb28ad066.png)
