### PR TITLE
Docker rustup fix

### DIFF
--- a/examples/prod_fastapi_demo/Dockerfile
+++ b/examples/prod_fastapi_demo/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-alpine as base
 
 FROM base as builder
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev make postgresql-dev
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev make postgresql-dev rustup && rustup-init -y
 RUN pip install poetry==1.0.3
 COPY . /src/
 WORKDIR /src

--- a/examples/prod_fastapi_demo/pyproject.toml
+++ b/examples/prod_fastapi_demo/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Aobo Shi <aobo.shi@decentfox.com>"]
 [tool.poetry.dependencies]
 python = "^3.6"
 fastapi = "^0.54.0"
-gino-starlette = {path = "../.."} # gino = {extras = ["starlette"], version = "^1.0.0"}
+gino = { extras = ["starlette"], version = "^1.0.0" }
 importlib_metadata = { version = "^1.3.0", python = "<3.8" }
 uvicorn = "^0.11.2"
 gunicorn = "^20.0.4"


### PR DESCRIPTION
- Fix missing rust toolchain dependency (fix #25)
- Remove reference to parent folder (You can't reference a parent folder from docker since it would be out of the project's context and as such not copied along with the source)