### PR TITLE
Remove duplicate code that runs migration twice

### DIFF
--- a/examples/prod_fastapi_demo/migrations/env.py
+++ b/examples/prod_fastapi_demo/migrations/env.py
@@ -90,15 +90,6 @@ def run_migrations_online():
         with context.begin_transaction():
             context.run_migrations()
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
-
-
 if context.is_offline_mode():
     run_migrations_offline()
 else:


### PR DESCRIPTION
There is no need to run migration twice since it's already been run at line 91